### PR TITLE
pr fail 9

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,4 @@
 ---
 
 WarningsAsErrors: '*,-clang-diagnostic-unused-function'
-Checks: >
-  *,
-  -llvm*
+Checks: bugprone-narrowing-conversions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
          # git diff -U0 "$(git merge-base HEAD "upstream/${{ github.event.pull_request.base.ref }}")" | clang-tidy-diff -p1 -path build -export-fixes clang-tidy-result/fixes.yml
          clang-tidy_ci -p build -export-fixes clang-tidy-result/fixes.yml comments_test.cpp
     - name: Run clang-tidy-pr-comments action
-      uses: platisd/clang-tidy-pr-comments@v1
+      uses: renefritze/clang-tidy-pr-comments@resolve_conversations
       if: always()
       with:
         # The GitHub token (or a personal access token)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       pull-requests: write
+      contents: write
     steps:
     - uses: actions/checkout@v4
       with:

--- a/comments_test.cpp
+++ b/comments_test.cpp
@@ -1,3 +1,3 @@
-double return_42() { return 42; }
+int return_42() { return 42; }
 
 int main() { return return_42(); }

--- a/comments_test.cpp
+++ b/comments_test.cpp
@@ -1,5 +1,3 @@
-int main()
+double return_42() { return 42; }
 
-{
-  return 0;
-}
+int main() { return return_42(); }


### PR DESCRIPTION
In this PR the "tidy fix" happens with the workflow having the proper write permission for closing conversations.
We get no annotation on the action run https://github.com/renefritze/tidy_comments_test/actions/runs/8345778749